### PR TITLE
✨ [Feat] Add discord message service to ExceptionAdvice

### DIFF
--- a/api-payload/pom.xml
+++ b/api-payload/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.namul</groupId>
         <artifactId>beginner</artifactId>
-        <version>0.4.2</version>
+        <version>0.5.0</version>
     </parent>
 
     <artifactId>api-payload</artifactId>

--- a/api-payload/src/main/java/org/namul/api/payload/config/DiscordSenderAutoConfiguration.java
+++ b/api-payload/src/main/java/org/namul/api/payload/config/DiscordSenderAutoConfiguration.java
@@ -1,0 +1,21 @@
+package org.namul.api.payload.config;
+
+import org.namul.api.payload.message.DiscordExceptionAdviceMessageSender;
+import org.namul.api.payload.message.DiscordExceptionAdviceUtil;
+import org.namul.api.payload.properties.DiscordProperties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+public class DiscordSenderAutoConfiguration {
+
+    @Bean
+    DiscordExceptionAdviceUtil discordUtil() {
+        return new DiscordExceptionAdviceUtil();
+    }
+
+    @Bean
+    DiscordExceptionAdviceMessageSender discordExceptionAdviceMessageSender(DiscordProperties discordProperties) {
+        return new DiscordExceptionAdviceMessageSender(discordUtil(), discordProperties);
+    }
+}

--- a/api-payload/src/main/java/org/namul/api/payload/config/ExceptionAdviceAutoConfiguration.java
+++ b/api-payload/src/main/java/org/namul/api/payload/config/ExceptionAdviceAutoConfiguration.java
@@ -5,6 +5,12 @@ import org.namul.api.payload.error.ExceptionAdvice;
 import org.namul.api.payload.error.configurer.ExceptionAdviceConfigurer;
 import org.namul.api.payload.log.DefaultExceptionAdviceLogger;
 import org.namul.api.payload.log.ExceptionAdviceLogger;
+import org.namul.api.payload.message.DiscordExceptionAdviceMessage;
+import org.namul.api.payload.message.DiscordExceptionAdviceMessageSender;
+import org.namul.api.payload.message.ExceptionAdviceMessageManager;
+import org.namul.api.payload.message.ExceptionAdviceMessageSender;
+import org.namul.api.payload.message.generator.DefaultDiscordExceptionAdviceMessageGenerator;
+import org.namul.api.payload.message.generator.ExceptionAdviceMessageGenerator;
 import org.namul.api.payload.writer.FailureResponseWriter;
 import org.namul.api.payload.writer.supports.DefaultFailureResponseWriter;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -12,7 +18,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
-@AutoConfiguration
+import java.util.Optional;
+
+@AutoConfiguration(
+        after = {DiscordSenderAutoConfiguration.class}
+)
 public class ExceptionAdviceAutoConfiguration {
 
     @Bean
@@ -29,7 +39,18 @@ public class ExceptionAdviceAutoConfiguration {
 
     @Bean
     @ConditionalOnBean(ExceptionAdviceConfigurer.class)
-    <R extends ErrorReasonDTO> ExceptionAdvice<R> exceptionAdvice(ExceptionAdviceConfigurer<R> exceptionAdviceConfigurer, ExceptionAdviceLogger exceptionAdviceLogger) {
-        return new ExceptionAdvice<>(exceptionAdviceConfigurer, exceptionAdviceLogger);
+    <R extends ErrorReasonDTO> ExceptionAdvice<R> exceptionAdvice(ExceptionAdviceConfigurer<R> exceptionAdviceConfigurer,
+                                                                  ExceptionAdviceLogger exceptionAdviceLogger,
+                                                                  ExceptionAdviceMessageManager exceptionAdviceMessageManager) {
+        return new ExceptionAdvice<>(exceptionAdviceConfigurer, exceptionAdviceLogger, exceptionAdviceMessageManager);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ExceptionAdviceMessageManager.class)
+    ExceptionAdviceMessageManager exceptionAdviceMessageManager(DiscordExceptionAdviceMessageSender discordExceptionAdviceMessageSender,
+                                                                Optional<ExceptionAdviceMessageGenerator<DiscordExceptionAdviceMessage>> discordGeneratorOptional) {
+        ExceptionAdviceMessageManager manager = new ExceptionAdviceMessageManager();
+        manager.addSender(discordExceptionAdviceMessageSender, discordGeneratorOptional.orElseGet(DefaultDiscordExceptionAdviceMessageGenerator::new));
+        return manager;
     }
 }

--- a/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdvice.java
+++ b/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdvice.java
@@ -8,6 +8,7 @@ import org.namul.api.payload.code.dto.ErrorReasonDTO;
 import org.namul.api.payload.error.configurer.ExceptionAdviceConfigurer;
 import org.namul.api.payload.handler.ExceptionAdviceHandler;
 import org.namul.api.payload.log.ExceptionAdviceLogger;
+import org.namul.api.payload.message.ExceptionAdviceMessageManager;
 import org.namul.api.payload.response.BaseResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -22,6 +23,7 @@ public class ExceptionAdvice<R extends ErrorReasonDTO> {
 
     private final ExceptionAdviceConfigurer<R> exceptionAdviceConfigurer;
     private final ExceptionAdviceLogger exceptionAdviceLogger;
+    private final ExceptionAdviceMessageManager exceptionAdviceMessageManager;
 
     /**
      * Handle method when exception occurs
@@ -34,6 +36,8 @@ public class ExceptionAdvice<R extends ErrorReasonDTO> {
         if (registry == null) {
             throw new IllegalArgumentException("The appropriate handler was not found.");
         }
+
+        exceptionAdviceMessageManager.sendMessage(request, registry.getCls(), e);
         return handleDelegated(e, request, response, registry);
     }
 

--- a/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdviceRegistry.java
+++ b/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdviceRegistry.java
@@ -14,6 +14,7 @@ import org.namul.api.payload.handler.ExceptionAdviceHandler;
 @RequiredArgsConstructor
 public class ExceptionAdviceRegistry<E extends Exception, R extends ErrorReasonDTO> {
 
+    private final Class<E> cls;
     private final ExceptionAdviceHandler<E, R> handler;
     private final R errorReasonDTO;
 }

--- a/api-payload/src/main/java/org/namul/api/payload/error/configurer/ExceptionAdviceConfigurer.java
+++ b/api-payload/src/main/java/org/namul/api/payload/error/configurer/ExceptionAdviceConfigurer.java
@@ -98,16 +98,6 @@ public class ExceptionAdviceConfigurer<R extends ErrorReasonDTO> {
     }
 
     /**
-     * The method that add ErrorReasonDTO with default exception handler about specific Exception
-     * @param cls The exception class
-     * @param r The Reason will be written in response
-     * @param <E> The exception type
-     */
-    public <E extends Exception> void addAdvice(Class<E> cls, R r) {
-        this.adviceMap.put(cls, new ExceptionAdviceRegistry<>(new GlobalExceptionHandler<>(this.failureResponseWriter), r));
-    }
-
-    /**
      * The method that add ErrorReasonDTO and handler about specific Exception
      * @param cls The exception class
      * @param handler The handler which handle exception
@@ -115,7 +105,7 @@ public class ExceptionAdviceConfigurer<R extends ErrorReasonDTO> {
      * @param <E> The exception type
      */
     public <E extends Exception> void addAdvice(Class<E> cls, ExceptionAdviceHandler<E, R> handler, R r) {
-        this.adviceMap.put(cls, new ExceptionAdviceRegistry<>(handler, r));
+        this.adviceMap.put(cls, new ExceptionAdviceRegistry<>(cls, handler, r));
     }
 
     /**

--- a/api-payload/src/main/java/org/namul/api/payload/message/DiscordExceptionAdviceMessage.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/DiscordExceptionAdviceMessage.java
@@ -1,0 +1,47 @@
+package org.namul.api.payload.message;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The discord message format
+ */
+@Builder
+@Getter
+public class DiscordExceptionAdviceMessage implements ExceptionAdviceMessage {
+
+    private String content;
+    private List<Embed> embeds;
+
+    public static DiscordExceptionAdviceMessage from(String content, String title1, String description1, String title2, String description2) {
+        List<Embed> embeds = new ArrayList<>();
+        embeds.add(Embed.from(title1, description1));
+        embeds.add(Embed.from(title2, description2));
+        return from(content, embeds);
+    }
+
+    public static DiscordExceptionAdviceMessage from(String content, List<Embed> embeds) {
+        return DiscordExceptionAdviceMessage.builder()
+                .content(content)
+                .embeds(embeds)
+                .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Embed {
+
+        private String title;
+        private String description;
+
+        public static Embed from(String title, String description) {
+            return Embed.builder()
+                    .title(title)
+                    .description(description)
+                    .build();
+        }
+    }
+}

--- a/api-payload/src/main/java/org/namul/api/payload/message/DiscordExceptionAdviceMessageSender.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/DiscordExceptionAdviceMessageSender.java
@@ -1,0 +1,24 @@
+package org.namul.api.payload.message;
+
+import lombok.RequiredArgsConstructor;
+import org.namul.api.payload.properties.DiscordProperties;
+
+/**
+ * The message sender that send message to discord with properties and discordUtil
+ */
+@RequiredArgsConstructor
+public class DiscordExceptionAdviceMessageSender implements ExceptionAdviceMessageSender<DiscordExceptionAdviceMessage> {
+
+    private final DiscordExceptionAdviceUtil discordUtil;
+    private final DiscordProperties discordProperties;
+
+    @Override
+    public void sendMessage(DiscordExceptionAdviceMessage discordExceptionAdviceMessage) {
+        discordUtil.sendAlarm(discordProperties.getWebHookUrl(), discordExceptionAdviceMessage);
+    }
+
+    @Override
+    public <E extends Exception> boolean isEnable(Class<E> cls) {
+        return discordProperties.isEnable() && discordProperties.getScope().contains(cls.getSimpleName());
+    }
+}

--- a/api-payload/src/main/java/org/namul/api/payload/message/DiscordExceptionAdviceUtil.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/DiscordExceptionAdviceUtil.java
@@ -1,0 +1,46 @@
+package org.namul.api.payload.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * The utility class for sending message to discord
+ */
+@Slf4j
+public class DiscordExceptionAdviceUtil {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Send message to discord webhook url
+     * @param webHookUrl The discord server webhook url
+     * @param discordMessage The message will be sent to discord
+     */
+    public void sendAlarm(String webHookUrl, DiscordExceptionAdviceMessage discordMessage) {
+        if (webHookUrl == null || webHookUrl.isEmpty() || discordMessage == null) {
+            log.warn("DiscordExceptionAdviceUtil: Cannot find Web hook url or discord message");
+            return;
+        }
+        try {
+            String jsonMessage = objectMapper.writeValueAsString(discordMessage);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Content-Type", "application/json");
+
+            HttpEntity<String> request = new HttpEntity<>(jsonMessage, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(webHookUrl, HttpMethod.POST, request, String.class);
+
+            if (response.getStatusCode() != HttpStatus.NO_CONTENT) {
+                log.warn("Failed to send Discord message: {}", response.getStatusCode());
+            }
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            log.warn("Failed to send Discord message", e);
+        }
+    }
+}

--- a/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessage.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessage.java
@@ -1,0 +1,9 @@
+package org.namul.api.payload.message;
+
+import java.io.Serializable;
+
+/**
+ * The Top-level interface for message will be sent
+ */
+public interface ExceptionAdviceMessage extends Serializable {
+}

--- a/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessageManager.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessageManager.java
@@ -1,0 +1,57 @@
+package org.namul.api.payload.message;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.namul.api.payload.message.generator.ExceptionAdviceMessageGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The message manager that manage sending message to another platform. Send message to other platforms by using sender and message generator
+ */
+@Getter
+public class ExceptionAdviceMessageManager {
+
+    private final List<ExceptionAdviceMessageSenderRegistry<?>> senders = new ArrayList<>();
+
+    /**
+     * Add message sender and generator
+     * @param sender The message sender that send to another platform.
+     * @param generator The message generator that generate message will be sent
+     * @param <T> The type of ExceptionAdviceMessage
+     */
+    public final <T extends ExceptionAdviceMessage> void addSender(ExceptionAdviceMessageSender<T> sender, ExceptionAdviceMessageGenerator<T> generator) {
+        senders.add(new ExceptionAdviceMessageSenderRegistry<>(sender, generator));
+    }
+
+    /**
+     * Send message about exception with each sender and generator
+     * @param request The HttpServletRequest to generate message.
+     * @param cls The class that register in properties as scope
+     * @param e The exception class that occurs actually
+     */
+    public void sendMessage(HttpServletRequest request, Class<? extends Exception> cls, Exception e) {
+        for (ExceptionAdviceMessageSenderRegistry<?> registry : senders) {
+            registry.sendMessage(request, cls, e);
+        }
+    }
+
+    /**
+     * The registry contains sender and generator
+     * @param <T> The type of ExceptionAdviceMessage
+     */
+    @Getter
+    @RequiredArgsConstructor
+    private static class ExceptionAdviceMessageSenderRegistry<T extends ExceptionAdviceMessage> {
+        private final ExceptionAdviceMessageSender<T> sender;
+        private final ExceptionAdviceMessageGenerator<T> generator;
+
+        public <E extends Exception> void sendMessage(HttpServletRequest request, Class<E> cls, Exception e) {
+            if (this.sender.isEnable(cls)) {
+                this.sender.sendMessage(this.generator.createMessage(request, e));
+            }
+        }
+    }
+}

--- a/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessageSender.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessageSender.java
@@ -1,0 +1,18 @@
+package org.namul.api.payload.message;
+
+public interface ExceptionAdviceMessageSender<T extends ExceptionAdviceMessage> {
+
+    /**
+     * Send error message to another platform
+     * @param t The message content will be sent
+     */
+    void sendMessage(T t);
+
+    /**
+     * Check whether to send message to another platform. it can check scope of properties with cls parameter
+     * @param cls The exception class that occurs
+     * @return Whether to send message
+     * @param <E> The type of exception class
+     */
+    <E extends Exception> boolean isEnable(Class<E> cls);
+}

--- a/api-payload/src/main/java/org/namul/api/payload/message/generator/DefaultDiscordExceptionAdviceMessageGenerator.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/generator/DefaultDiscordExceptionAdviceMessageGenerator.java
@@ -1,0 +1,66 @@
+package org.namul.api.payload.message.generator;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.namul.api.payload.message.DiscordExceptionAdviceMessage;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+
+/**
+ * Default discord message generator
+ */
+public class DefaultDiscordExceptionAdviceMessageGenerator implements ExceptionAdviceMessageGenerator<DiscordExceptionAdviceMessage> {
+
+    private static final String DISCORD_CONTENT = "# 🚨 Error";
+    private static final String DISCORD_TITLE = "ℹ️ Error Info";
+    private static final String DISCORD_DESCRIPTION_FORMAT = "### 🕖 Time\n%s\n### 🔗 Request URL\n%s\n### 📝 Message\n```\n%s\n```";
+    private static final String DISCORD_STACK_TRACE_TITLE = "📚 Stack Trace";
+    private static final String DISCORD_STACK_TRACE_DESCRIPTION_FORMAT = "```\n%s\n```";
+
+    @Override
+    public DiscordExceptionAdviceMessage createMessage(HttpServletRequest request, Exception exception) {
+        String description = String.format(DISCORD_DESCRIPTION_FORMAT, LocalDateTime.now(), createRequestFullPath(request), getErrorMethodAndClass(exception));
+        return DiscordExceptionAdviceMessage.from(DISCORD_CONTENT, DISCORD_TITLE, description, DISCORD_STACK_TRACE_TITLE, String.format(DISCORD_STACK_TRACE_DESCRIPTION_FORMAT, getStackTrace(exception).substring(0, 1000)));
+    }
+
+    /**
+     * Create request uri for message
+     * @return The created request path
+     */
+    private String createRequestFullPath(HttpServletRequest request) {
+        String fullPath = request.getMethod() + " " + request.getRequestURL();
+
+        String queryString = request.getQueryString();
+        if (queryString != null) {
+            fullPath += "?" + queryString;
+        }
+
+        return fullPath;
+    }
+
+    /**
+     * Get stack trace for message
+     * @param e The exception that occurs
+     * @return The string contains stack trace
+     */
+    private String getStackTrace(Exception e) {
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
+    }
+
+    /**
+     * The method and class data that exception occurs
+     * @param e The exception that occurs
+     * @return The method and class data
+     */
+    private String getErrorMethodAndClass(Exception e) {
+        StackTraceElement[] stackTraces = e.getStackTrace();
+        if (stackTraces.length > 0) {
+            StackTraceElement stackTrace = stackTraces[0];
+            return "Method: " + stackTrace.getMethodName() + "\n Class: " + stackTrace.getClassName();
+        }
+        return null;
+    }
+}

--- a/api-payload/src/main/java/org/namul/api/payload/message/generator/ExceptionAdviceMessageGenerator.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/generator/ExceptionAdviceMessageGenerator.java
@@ -1,0 +1,13 @@
+package org.namul.api.payload.message.generator;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.namul.api.payload.message.ExceptionAdviceMessage;
+
+/**
+ * The message generator for ExceptionAdviceMessage
+ * @param <T> The type of ExceptionAdviceMessage
+ */
+public interface ExceptionAdviceMessageGenerator<T extends ExceptionAdviceMessage> {
+
+    T createMessage(HttpServletRequest request, Exception exception);
+}

--- a/api-payload/src/main/java/org/namul/api/payload/properties/DiscordProperties.java
+++ b/api-payload/src/main/java/org/namul/api/payload/properties/DiscordProperties.java
@@ -1,0 +1,31 @@
+package org.namul.api.payload.properties;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Setter
+@Getter
+@ConfigurationProperties(prefix = "beginner.api.payload.discord")
+public class DiscordProperties {
+
+    /**
+     * Whether to enable sending message to discord
+     */
+    private boolean enable = false;
+
+    /**
+     * The exception name to use discord when it occurs
+     */
+    private List<String> scope = new ArrayList<>();
+
+    /**
+     * The discord web hook url to send message
+     */
+    private String webHookUrl = null;
+
+}

--- a/api-payload/src/main/java/org/namul/api/payload/properties/config/DiscordAutoConfiguration.java
+++ b/api-payload/src/main/java/org/namul/api/payload/properties/config/DiscordAutoConfiguration.java
@@ -1,0 +1,10 @@
+package org.namul.api.payload.properties.config;
+
+import org.namul.api.payload.properties.DiscordProperties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@AutoConfiguration
+@EnableConfigurationProperties({DiscordProperties.class})
+public class DiscordAutoConfiguration {
+}

--- a/api-payload/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/api-payload/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,4 @@
 org.namul.api.payload.config.DefaultResponseAutoConfiguration
 org.namul.api.payload.config.ExceptionAdviceAutoConfiguration
+org.namul.api.payload.config.DiscordSenderAutoConfiguration
+org.namul.api.payload.properties.config.DiscordAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.namul</groupId>
   <artifactId>beginner</artifactId>
-  <version>0.4.2</version>
+  <version>0.5.0</version>
   <packaging>pom</packaging>
 
   <description>


### PR DESCRIPTION
## 📍 PR Type 
- [x] Implement feature
- [ ] Fix a bug
- [ ] Refactor
- [ ] Chore

## ❗️ Related Issue
Close #35 

## 📌Outline 
- Add discord message service to ExceptionAdvice

## 🔁 Changes (Commit id and description)
https://github.com/projectnamul/beginner/commit/ede83bd41bf2130297007863814461c0d039a68b
- Add ExceptionAdviceMessage that contains data about error to sending another platform
- Add ExceptionAdviceMessageSender that send message to another platform
- Add ExceptionAdviceMessageManager to manage message that will be sent to another platform all at once
- Add discord properties and AutoConfiguration to configure WebHookUrl, Scope, enable with properties
- Add discord message sender and util to send message to discord server
- Add ExceptionAdviceMessageManager in ExceptionAdvice to send message when exception occurs

## 👀 Additional Comment(Optional)
