### PR TITLE
⚡️ [Perf] Change message sender's method in ExceptionAdvice to asynchronous

### DIFF
--- a/api-payload/pom.xml
+++ b/api-payload/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.namul</groupId>
         <artifactId>beginner</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
     </parent>
 
     <artifactId>api-payload</artifactId>

--- a/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdvice.java
+++ b/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdvice.java
@@ -37,7 +37,7 @@ public class ExceptionAdvice<R extends ErrorReasonDTO> {
             throw new IllegalArgumentException("The appropriate handler was not found.");
         }
 
-        exceptionAdviceMessageManager.sendMessage(request, registry.getCls(), e);
+        exceptionAdviceMessageManager.sendMessageAsync(request, registry.getCls(), e);
         return handleDelegated(e, request, response, registry);
     }
 

--- a/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessageManager.java
+++ b/api-payload/src/main/java/org/namul/api/payload/message/ExceptionAdviceMessageManager.java
@@ -7,6 +7,7 @@ import org.namul.api.payload.message.generator.ExceptionAdviceMessageGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.*;
 
 /**
  * The message manager that manage sending message to another platform. Send message to other platforms by using sender and message generator
@@ -15,6 +16,14 @@ import java.util.List;
 public class ExceptionAdviceMessageManager {
 
     private final List<ExceptionAdviceMessageSenderRegistry<?>> senders = new ArrayList<>();
+    private final Executor executor = new ThreadPoolExecutor(
+            10,
+            100,
+            60L, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(1000),
+            Executors.defaultThreadFactory(),
+            new ThreadPoolExecutor.CallerRunsPolicy()
+    );
 
     /**
      * Add message sender and generator
@@ -24,6 +33,16 @@ public class ExceptionAdviceMessageManager {
      */
     public final <T extends ExceptionAdviceMessage> void addSender(ExceptionAdviceMessageSender<T> sender, ExceptionAdviceMessageGenerator<T> generator) {
         senders.add(new ExceptionAdviceMessageSenderRegistry<>(sender, generator));
+    }
+
+    /**
+     * The method of asynchronous processing of message transfer
+     * @param request The HttpServletRequest to generate message.
+     * @param cls The class that register in properties as scope
+     * @param e The exception class that occurs actually
+     */
+    public void sendMessageAsync(HttpServletRequest request, Class<? extends Exception> cls, Exception e) {
+        CompletableFuture.runAsync(() -> sendMessage(request, cls, e), executor);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.namul</groupId>
   <artifactId>beginner</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
   <packaging>pom</packaging>
 
   <description>


### PR DESCRIPTION
## 📍 PR Type 
- [ ] Implement feature
- [ ] Fix a bug
- [ ] Refactor
- [x] Chore (Improve performance)

## ❗️ Related Issue
Close #38 

## 📌Outline 
- Change message sender's method in ExceptionAdvice to asynchronous

## 🔁 Changes (Commit id and description)
https://github.com/projectnamul/beginner/commit/e5ba8656fc29b3b49d77907bc7bc99c609bb04b9
- Add and apply Executor in ExceptionAdviceMessageManager to process sending message asynchronous

## 👀 Additional Comment(Optional)
### Environment
#### EC2
- Amazon Linux 2023 AMI (al2023-ami-2023.7.20250527.1-kernel-6.1-x86_64)
- t2.micro
- 1 vCpu
- 1 volume (8 GiB gp3)

#### Database
- MySQL 8.0.41
- 1 Instance
- db.t4g.micro
- Storage: gp2, 20GiB
- 2 vCPU
- RAM: 1GB

### Test
- Test exception advice that sends messages synchronously with 30 VUs for 20s. When a user sends two requests, one fails and one succeeds
<img width="1124" alt="Screenshot 2025-06-07 at 22 46 45" src="https://github.com/user-attachments/assets/cc95d178-aa61-4161-8812-dabac9f03f89" />


- Test exception advice that sends messages asynchronously with 30 VUs for 20s. When a user sends two requests, one fails and one succeeds
<img width="1099" alt="Screenshot 2025-06-07 at 22 38 59" src="https://github.com/user-attachments/assets/4adbf194-76c3-411e-bf37-20a016593a67" />


### Perf
- Performance (throughput per second) increases by 4 times (92 -> 364)

### Why not WebClient
- The reason why I didn't use WebClient is to avoid increasing the coupling of the beginner dependencies with external ones
