### PR TITLE
✨  [Feat] Add methods that use BaseErrorCode and mark oldMethod as Deprecated

### DIFF
--- a/api-payload/pom.xml
+++ b/api-payload/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.namul</groupId>
         <artifactId>beginner</artifactId>
-        <version>0.7.0</version>
+        <version>0.7.1</version>
     </parent>
 
     <artifactId>api-payload</artifactId>

--- a/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdviceConfigurer.java
+++ b/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdviceConfigurer.java
@@ -3,6 +3,7 @@ package org.namul.api.payload.error;
 import jakarta.validation.ConstraintViolationException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.namul.api.payload.code.BaseErrorCode;
 import org.namul.api.payload.code.dto.ErrorReasonDTO;
 import org.namul.api.payload.error.exception.ServerApplicationException;
 import org.namul.api.payload.handler.*;
@@ -27,6 +28,16 @@ public class ExceptionAdviceConfigurer {
     private final Map<Class<? extends Exception>, ExceptionAdviceRegistry<? extends Exception>> adviceMap = new HashMap<>();
     private final FailureResponseWriter failureResponseWriter;
     private final List<AdditionalExceptionHandler> additionalExceptionHandlers = new ArrayList<>();
+
+    /**
+     * The method for Default configuration
+     * @param badRequestError The BaseErrorCode that can return ErrorReasonDTO for bad request error
+     * @param internalServerError The BaseErrorCode that can return ErrorReasonDTO for internal server error
+     */
+    public ExceptionAdviceConfigurer withDefault(BaseErrorCode badRequestError,
+                                                 BaseErrorCode internalServerError) {
+        return this.withDefault(badRequestError.getReason(), internalServerError.getReason());
+    }
 
     /**
      * The method for Default configuration
@@ -69,8 +80,192 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ExceptionHandler and ErrorReasonDTO about ConstraintViolationException
      * @param handler The handler which handle ConstraintViolationException
-     * @param r The Reason will be written in response
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
      */
+    public ExceptionAdviceConfigurer addConstraintViolation(ExceptionAdviceHandler<ConstraintViolationException> handler, BaseErrorCode code) {
+        return this.addAdvice(ConstraintViolationException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about MethodArgumentNotValidException
+     * @param handler The handler which handle MethodArgumentNotValidException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addMethodArgumentNotValid(ExceptionAdviceHandler<MethodArgumentNotValidException> handler, BaseErrorCode code) {
+        return this.addAdvice(MethodArgumentNotValidException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about HttpMessageNotReadableException
+     * @param handler The handler which handle HttpMessageNotReadableException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addHttpMessageNotReadable(ExceptionAdviceHandler<HttpMessageNotReadableException> handler, BaseErrorCode code) {
+        return this.addAdvice(HttpMessageNotReadableException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about HttpRequestMethodNotSupportedException
+     * @param handler The handler which handle HttpRequestMethodNotSupportedException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addHttpRequestMethodNotSupported(ExceptionAdviceHandler<HttpRequestMethodNotSupportedException> handler, BaseErrorCode code) {
+        return this.addAdvice(HttpRequestMethodNotSupportedException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about MissingPathVariableException
+     * @param handler The handler which handle MissingPathVariableException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addMissingPathVariable(ExceptionAdviceHandler<MissingPathVariableException> handler, BaseErrorCode code) {
+        return this.addAdvice(MissingPathVariableException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about MissingServletRequestParameterException
+     * @param handler The handler which handle MissingServletRequestParameterException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addMissingServletRequestParameter(ExceptionAdviceHandler<MissingServletRequestParameterException> handler, BaseErrorCode code) {
+        return this.addAdvice(MissingServletRequestParameterException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about NoResourceFoundException
+     * @param handler The handler which handle NoResourceFoundException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addNoResourceFound(ExceptionAdviceHandler<NoResourceFoundException> handler, BaseErrorCode code) {
+        return this.addAdvice(NoResourceFoundException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about TypeMismatchException
+     * @param handler The handler which handle TypeMismatchException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addTypeMismatch(ExceptionAdviceHandler<TypeMismatchException> handler, BaseErrorCode code) {
+        return this.addAdvice(TypeMismatchException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about ServerApplicationException
+     * @param handler The handler which handle ServerApplicationException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addServerApplication(ExceptionAdviceHandler<ServerApplicationException> handler, BaseErrorCode code) {
+        return this.addAdvice(ServerApplicationException.class, handler, code);
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about Exception
+     * @param handler The handler which handle Exception
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addGlobalException(ExceptionAdviceHandler<Exception> handler, BaseErrorCode code) {
+        return this.addAdvice(Exception.class, handler, code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about ConstraintViolationException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addConstraintViolation(BaseErrorCode code) {
+        return this.addAdvice(ConstraintViolationException.class, new ConstraintViolationExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about MethodArgumentNotValidException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addMethodArgumentNotValid(BaseErrorCode code) {
+        return this.addAdvice(MethodArgumentNotValidException.class, new MethodArgumentNotValidExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about HttpMessageNotReadableException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addHttpMessageNotReadable(BaseErrorCode code) {
+        return this.addAdvice(HttpMessageNotReadableException.class, new HttpMessageNotReadableExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about HttpRequestMethodNotSupported
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addHttpRequestMethodNotSupported(BaseErrorCode code) {
+        return this.addAdvice(HttpRequestMethodNotSupportedException.class, new HttpRequestMethodNotSupportedExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about MissingPathVariableException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addMissingPathVariable(BaseErrorCode code) {
+        return this.addAdvice(MissingPathVariableException.class, new MissingPathVariableExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about MissingServletRequestParameterException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addMissingServletRequestParameter(BaseErrorCode code) {
+        return this.addAdvice(MissingServletRequestParameterException.class, new MissingServletRequestParameterExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about NoResourceFoundException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addNoResourceFound(BaseErrorCode code) {
+        return this.addAdvice(NoResourceFoundException.class, new NoResourceFoundExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about TypeMismatchException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addTypeMismatch(BaseErrorCode code) {
+        return this.addAdvice(TypeMismatchException.class, new TypeMismatchExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about ServerApplicationException
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addServerApplication(BaseErrorCode code) {
+        return this.addAdvice(ServerApplicationException.class, new ServerApplicationExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO with default handler about Exception
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     */
+    public ExceptionAdviceConfigurer addGlobalException(BaseErrorCode code) {
+        return this.addAdvice(Exception.class, new GlobalExceptionHandler(this.failureResponseWriter), code);
+    }
+
+    /**
+     * The method that add ErrorReasonDTO and handler about specific Exception
+     * @param cls The exception class
+     * @param handler The handler which handle exception
+     * @param code The BaseErrorCode which return ErrorReasonDTO that will be written in response
+     * @param <E> The exception type
+     */
+    public <E extends Exception> ExceptionAdviceConfigurer addAdvice(Class<E> cls, ExceptionAdviceHandler<E> handler, BaseErrorCode code) {
+        this.adviceMap.put(cls, new ExceptionAdviceRegistry<>(cls, handler, code.getReason()));
+        return this;
+    }
+
+    /**
+     * The method that add ExceptionHandler and ErrorReasonDTO about ConstraintViolationException
+     * @param handler The handler which handle ConstraintViolationException
+     * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addConstraintViolation(ExceptionAdviceHandler, BaseErrorCode)} instead
+     */
+    @Deprecated
     public ExceptionAdviceConfigurer addConstraintViolation(ExceptionAdviceHandler<ConstraintViolationException> handler, ErrorReasonDTO r) {
         return this.addAdvice(ConstraintViolationException.class, handler, r);
     }
@@ -79,7 +274,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about MethodArgumentNotValidException
      * @param handler The handler which handle MethodArgumentNotValidException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addMethodArgumentNotValid(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addMethodArgumentNotValid(ExceptionAdviceHandler<MethodArgumentNotValidException> handler, ErrorReasonDTO r) {
         return this.addAdvice(MethodArgumentNotValidException.class, handler, r);
     }
@@ -88,7 +285,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about HttpMessageNotReadableException
      * @param handler The handler which handle HttpMessageNotReadableException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addHttpMessageNotReadable(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addHttpMessageNotReadable(ExceptionAdviceHandler<HttpMessageNotReadableException> handler, ErrorReasonDTO r) {
         return this.addAdvice(HttpMessageNotReadableException.class, handler, r);
     }
@@ -97,7 +296,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about HttpRequestMethodNotSupportedException
      * @param handler The handler which handle HttpRequestMethodNotSupportedException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addHttpRequestMethodNotSupported(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addHttpRequestMethodNotSupported(ExceptionAdviceHandler<HttpRequestMethodNotSupportedException> handler, ErrorReasonDTO r) {
         return this.addAdvice(HttpRequestMethodNotSupportedException.class, handler, r);
     }
@@ -106,7 +307,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about MissingPathVariableException
      * @param handler The handler which handle MissingPathVariableException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addMissingPathVariable(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addMissingPathVariable(ExceptionAdviceHandler<MissingPathVariableException> handler, ErrorReasonDTO r) {
         return this.addAdvice(MissingPathVariableException.class, handler, r);
     }
@@ -115,7 +318,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about MissingServletRequestParameterException
      * @param handler The handler which handle MissingServletRequestParameterException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addMissingServletRequestParameter(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addMissingServletRequestParameter(ExceptionAdviceHandler<MissingServletRequestParameterException> handler, ErrorReasonDTO r) {
         return this.addAdvice(MissingServletRequestParameterException.class, handler, r);
     }
@@ -124,7 +329,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about NoResourceFoundException
      * @param handler The handler which handle NoResourceFoundException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addNoResourceFound(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addNoResourceFound(ExceptionAdviceHandler<NoResourceFoundException> handler, ErrorReasonDTO r) {
         return this.addAdvice(NoResourceFoundException.class, handler, r);
     }
@@ -133,7 +340,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about TypeMismatchException
      * @param handler The handler which handle TypeMismatchException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addTypeMismatch(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addTypeMismatch(ExceptionAdviceHandler<TypeMismatchException> handler, ErrorReasonDTO r) {
         return this.addAdvice(TypeMismatchException.class, handler, r);
     }
@@ -142,7 +351,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about ServerApplicationException
      * @param handler The handler which handle ServerApplicationException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addServerApplication(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addServerApplication(ExceptionAdviceHandler<ServerApplicationException> handler, ErrorReasonDTO r) {
         return this.addAdvice(ServerApplicationException.class, handler, r);
     }
@@ -151,7 +362,9 @@ public class ExceptionAdviceConfigurer {
      * The method that add ExceptionHandler and ErrorReasonDTO about Exception
      * @param handler The handler which handle Exception
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addGlobalException(ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addGlobalException(ExceptionAdviceHandler<Exception> handler, ErrorReasonDTO r) {
         return this.addAdvice(Exception.class, handler, r);
     }
@@ -159,7 +372,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about ConstraintViolationException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addConstraintViolation(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addConstraintViolation(ErrorReasonDTO r) {
         return this.addAdvice(ConstraintViolationException.class, new ConstraintViolationExceptionHandler(this.failureResponseWriter), r);
     }
@@ -167,7 +382,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about MethodArgumentNotValidException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addMethodArgumentNotValid(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addMethodArgumentNotValid(ErrorReasonDTO r) {
         return this.addAdvice(MethodArgumentNotValidException.class, new MethodArgumentNotValidExceptionHandler(this.failureResponseWriter), r);
     }
@@ -175,7 +392,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about HttpMessageNotReadableException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addHttpMessageNotReadable(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addHttpMessageNotReadable(ErrorReasonDTO r) {
         return this.addAdvice(HttpMessageNotReadableException.class, new HttpMessageNotReadableExceptionHandler(this.failureResponseWriter), r);
     }
@@ -183,7 +402,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about HttpRequestMethodNotSupported
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addHttpRequestMethodNotSupported(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addHttpRequestMethodNotSupported(ErrorReasonDTO r) {
         return this.addAdvice(HttpRequestMethodNotSupportedException.class, new HttpRequestMethodNotSupportedExceptionHandler(this.failureResponseWriter), r);
     }
@@ -191,7 +412,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about MissingPathVariableException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addMissingPathVariable(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addMissingPathVariable(ErrorReasonDTO r) {
         return this.addAdvice(MissingPathVariableException.class, new MissingPathVariableExceptionHandler(this.failureResponseWriter), r);
     }
@@ -199,7 +422,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about MissingServletRequestParameterException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addMissingServletRequestParameter(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addMissingServletRequestParameter(ErrorReasonDTO r) {
         return this.addAdvice(MissingServletRequestParameterException.class, new MissingServletRequestParameterExceptionHandler(this.failureResponseWriter), r);
     }
@@ -207,7 +432,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about NoResourceFoundException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addNoResourceFound(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addNoResourceFound(ErrorReasonDTO r) {
         return this.addAdvice(NoResourceFoundException.class, new NoResourceFoundExceptionHandler(this.failureResponseWriter), r);
     }
@@ -215,7 +442,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about TypeMismatchException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addTypeMismatch(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addTypeMismatch(ErrorReasonDTO r) {
         return this.addAdvice(TypeMismatchException.class, new TypeMismatchExceptionHandler(this.failureResponseWriter), r);
     }
@@ -223,7 +452,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about ServerApplicationException
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addServerApplication(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addServerApplication(ErrorReasonDTO r) {
         return this.addAdvice(ServerApplicationException.class, new ServerApplicationExceptionHandler(this.failureResponseWriter), r);
     }
@@ -231,7 +462,9 @@ public class ExceptionAdviceConfigurer {
     /**
      * The method that add ErrorReasonDTO with default handler about Exception
      * @param r The Reason will be written in response
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addGlobalException(BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer addGlobalException(ErrorReasonDTO r) {
         return this.addAdvice(Exception.class, new GlobalExceptionHandler(this.failureResponseWriter), r);
     }
@@ -242,7 +475,9 @@ public class ExceptionAdviceConfigurer {
      * @param handler The handler which handle exception
      * @param r The Reason will be written in response
      * @param <E> The exception type
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #addAdvice(Class, ExceptionAdviceHandler, BaseErrorCode)} instead
      */
+    @Deprecated
     public <E extends Exception> ExceptionAdviceConfigurer addAdvice(Class<E> cls, ExceptionAdviceHandler<E> handler, ErrorReasonDTO r) {
         this.adviceMap.put(cls, new ExceptionAdviceRegistry<>(cls, handler, r));
         return this;

--- a/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdviceConfigurer.java
+++ b/api-payload/src/main/java/org/namul/api/payload/error/ExceptionAdviceConfigurer.java
@@ -36,14 +36,26 @@ public class ExceptionAdviceConfigurer {
      */
     public ExceptionAdviceConfigurer withDefault(BaseErrorCode badRequestError,
                                                  BaseErrorCode internalServerError) {
-        return this.withDefault(badRequestError.getReason(), internalServerError.getReason());
+        return this
+                .addConstraintViolation(badRequestError)
+                .addMethodArgumentNotValid(badRequestError)
+                .addHttpMessageNotReadable(badRequestError)
+                .addHttpRequestMethodNotSupported(badRequestError)
+                .addMissingPathVariable(badRequestError)
+                .addMissingServletRequestParameter(badRequestError)
+                .addNoResourceFound(badRequestError)
+                .addTypeMismatch(badRequestError)
+                .addServerApplication(badRequestError)
+                .addGlobalException(internalServerError);
     }
 
     /**
      * The method for Default configuration
      * @param badRequestError The error reason DTO for bad request
      * @param internalServerError The error reason DTO for internal server error
+     * @deprecated since 0.7.1, will be removed in a future release, Use {@link #withDefault(BaseErrorCode, BaseErrorCode)} instead
      */
+    @Deprecated
     public ExceptionAdviceConfigurer withDefault(ErrorReasonDTO badRequestError,
                             ErrorReasonDTO internalServerError) {
         return this

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.namul</groupId>
   <artifactId>beginner</artifactId>
-  <version>0.7.0</version>
+  <version>0.7.1</version>
   <packaging>pom</packaging>
 
   <description>


### PR DESCRIPTION
## 📍 PR Type 
- [x] Implement feature
- [ ] Fix a bug
- [ ] Refactor
- [ ] Chore

## ❗️ Related Issue
Close #55 

## 📌Outline 
- Add methods that use BaseErrorCode and mark oldMethod as Deprecated

## 🔁 Changes (Commit id and description)
- Add methods that use BaseErrorCode instead of ErrorReasonDTO in Configurer
- Mark methods that use ErrorReasonDTO as Deprecated

## 👀 Additional Comment(Optional)
